### PR TITLE
Fixed header issue

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/TermiNetwork/Classes/TNCall.swift
+++ b/TermiNetwork/Classes/TNCall.swift
@@ -103,7 +103,9 @@ open class TNCall {
         
         params?.merge(TNCall.fixedHeaders, uniquingKeysWith: { (_, new) in new })
         
-        request.allHTTPHeaderFields = params as? [String : String]
+        for (headerFieldKey, headerFieldValue) in params! {
+            request.addValue(headerFieldValue as! String, forHTTPHeaderField: headerFieldKey)
+        }
         request.httpMethod = method.rawValue
         
         if timeoutInterval != nil {


### PR DESCRIPTION
The general params variable which is also used for headers is of type [String: Any]. This conflicts with the http header requested type which is [String: String] and may raise server-side errors.

 In this suggested change, addValue function in a for loop for every header in params dictionary is used instead of allHTTPHeaderFields in order to populate the header fields.